### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu
+
+ADD . /config
+
+WORKDIR /config
+
+RUN apt update && apt install -y emacs25 git ispell
+
+RUN ./install.sh
+
+CMD ["emacs"]


### PR DESCRIPTION
Why dockerize? Well, I often have trouble testing whether my emacs config still self-installs properly, since I already have it installed on the machine I'm developing it on. Using Docker, I can fire up basically a clean new Ubuntu instance and test the self-install functionality.